### PR TITLE
Removed storing IHostingEnvironment dependency; added ILoggerFactory dependency

### DIFF
--- a/src/ExtCore.WebApplication/Code/CompositeFileProvider.cs
+++ b/src/ExtCore.WebApplication/Code/CompositeFileProvider.cs
@@ -8,165 +8,186 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Hosting;
+using ExtCore.Infrastructure;
 
 namespace ExtCore.WebApplication
 {
-  public class CompositeFileProvider : IFileProvider
-  {
-    private readonly IEnumerable<IFileProvider> fileProviders;
-
-    public CompositeFileProvider(IEnumerable<IFileProvider> fileProviders)
+    public class CompositeFileProvider : IFileProvider
     {
-      this.fileProviders = fileProviders;
+        private readonly IEnumerable<IFileProvider> fileProviders;
+
+        public CompositeFileProvider(IEnumerable<IFileProvider> fileProviders)
+        {
+            this.fileProviders = fileProviders;
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+            foreach (IFileProvider fileProvider in this.fileProviders)
+            {
+                IDirectoryContents directoryContents = fileProvider.GetDirectoryContents(subpath);
+
+                if (directoryContents != null && directoryContents.Exists)
+                    return directoryContents;
+            }
+
+            return new NonexistentDirectoryContents();
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            foreach (IFileProvider fileProvider in this.fileProviders)
+            {
+                IFileInfo fileInfo = fileProvider.GetFileInfo(subpath);
+
+                if (fileInfo != null && fileInfo.Exists)
+                    return fileInfo;
+            }
+
+            return new NonexistentFileInfo(subpath);
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            foreach (IFileProvider fileProvider in this.fileProviders)
+            {
+                IChangeToken changeToken = fileProvider.Watch(filter);
+
+                if (changeToken != null)
+                    return changeToken;
+            }
+
+            return NonexistentChangeToken.Singleton;
+        }
     }
 
-    public IDirectoryContents GetDirectoryContents(string subpath)
+    internal class NonexistentDirectoryContents : IDirectoryContents
     {
-      foreach (IFileProvider fileProvider in this.fileProviders)
-      {
-        IDirectoryContents directoryContents = fileProvider.GetDirectoryContents(subpath);
+        public bool Exists
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-        if (directoryContents != null && directoryContents.Exists)
-          return directoryContents;
-      }
+        public IEnumerator<IFileInfo> GetEnumerator()
+        {
+            return Enumerable.Empty<IFileInfo>().GetEnumerator();
+        }
 
-      return new NonexistentDirectoryContents();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
     }
 
-    public IFileInfo GetFileInfo(string subpath)
+    internal class NonexistentFileInfo : IFileInfo
     {
-      foreach (IFileProvider fileProvider in this.fileProviders)
-      {
-        IFileInfo fileInfo = fileProvider.GetFileInfo(subpath);
+        private readonly string name;
 
-        if (fileInfo != null && fileInfo.Exists)
-          return fileInfo;
-      }
+        public NonexistentFileInfo(string name)
+        {
+            this.name = name;
+        }
 
-      return new NonexistentFileInfo(subpath);
+        public bool Exists
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public bool IsDirectory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public DateTimeOffset LastModified
+        {
+            get
+            {
+                return DateTimeOffset.MinValue;
+            }
+        }
+
+        public long Length
+        {
+            get
+            {
+                return -1;
+            }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return this.name;
+            }
+        }
+
+        public string PhysicalPath
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public Stream CreateReadStream()
+        {
+            throw new FileNotFoundException(this.name);
+        }
     }
 
-    public IChangeToken Watch(string filter)
+    internal class NonexistentChangeToken : IChangeToken
     {
-      foreach (IFileProvider fileProvider in this.fileProviders)
-      {
-        IChangeToken changeToken = fileProvider.Watch(filter);
+        public static NonexistentChangeToken Singleton { get; } = new NonexistentChangeToken();
 
-        if (changeToken != null)
-          return changeToken;
-      }
+        public bool ActiveChangeCallbacks
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
 
-      return NonexistentChangeToken.Singleton;
-    }
-  }
+        public bool HasChanged
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
 
-  internal class NonexistentDirectoryContents : IDirectoryContents
-  {
-    public bool Exists
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public IEnumerator<IFileInfo> GetEnumerator()
-    {
-      return Enumerable.Empty<IFileInfo>().GetEnumerator();
+        public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+        {
+            throw new NotImplementedException();
+        }
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
+    public static class IHostingEnvironmentExtensions
     {
-      return this.GetEnumerator();
+        public static IHostingEnvironment AddCompositeFileProvider(this IHostingEnvironment hostingEnvironment)
+        {
+            IEnumerable<IFileProvider> fileProviders = new IFileProvider[] {
+                hostingEnvironment.WebRootFileProvider
+            };
+
+            var compositeFileProvider = new CompositeFileProvider(
+                fileProviders.Concat(
+                    ExtensionManager.Assemblies.Select(a => new EmbeddedFileProvider(a, a.GetName().Name))
+                )
+            );
+            hostingEnvironment.WebRootFileProvider = compositeFileProvider;
+
+            return hostingEnvironment;
+        }
     }
-  }
-
-  internal class NonexistentFileInfo : IFileInfo
-  {
-    private readonly string name;
-
-    public NonexistentFileInfo(string name)
-    {
-      this.name = name;
-    }
-
-    public bool Exists
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public bool IsDirectory
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public DateTimeOffset LastModified
-    {
-      get
-      {
-        return DateTimeOffset.MinValue;
-      }
-    }
-
-    public long Length
-    {
-      get
-      {
-        return -1;
-      }
-    }
-
-    public string Name
-    {
-      get
-      {
-        return this.name;
-      }
-    }
-
-    public string PhysicalPath
-    {
-      get
-      {
-        return null;
-      }
-    }
-
-    public Stream CreateReadStream()
-    {
-      throw new FileNotFoundException(this.name);
-    }
-  }
-
-  internal class NonexistentChangeToken : IChangeToken
-  {
-    public static NonexistentChangeToken Singleton { get; } = new NonexistentChangeToken();
-
-    public bool ActiveChangeCallbacks
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public bool HasChanged
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public IDisposable RegisterChangeCallback(Action<object> callback, object state)
-    {
-      throw new NotImplementedException();
-    }
-  }
 }

--- a/src/ExtCore.WebApplication/Startup.cs
+++ b/src/ExtCore.WebApplication/Startup.cs
@@ -21,7 +21,7 @@ namespace ExtCore.WebApplication
   {
     protected IConfigurationRoot configurationRoot;
 
-    public Startup(IHostingEnvironment hostingEnvironment)
+    public Startup(IHostingEnvironment hostingEnvironment, ILoggerFactory loggerFactory)
     {
       DiscoverAssemblies();
       hostingEnvironment.AddCompositeFileProvider();
@@ -38,7 +38,7 @@ namespace ExtCore.WebApplication
       }
     }
 
-    public virtual void Configure(IApplicationBuilder applicationBuilder, IHostingEnvironment hostingEnvironment)
+    public virtual void Configure(IApplicationBuilder applicationBuilder, IHostingEnvironment hostingEnvironment, ILoggerFactory loggerFactory)
     {
       applicationBuilder.UseStaticFiles();
 


### PR DESCRIPTION
I think we can do without storing IHostingEnvironment in Startup.
And by adding ILoggerFactory a derived Startup class can use this to configure logging.