### PR TITLE
Added EmbeddedFileProvider that queries for match

### DIFF
--- a/src/ExtCore.Mvc/EmbeddedEndsWithFileProvider.cs
+++ b/src/ExtCore.Mvc/EmbeddedEndsWithFileProvider.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Embedded;
+using Microsoft.Extensions.Primitives;
+
+namespace ExtCore.Mvc
+{
+    public class EmbeddedEndsWithFileProvider : IFileProvider
+    {
+        private readonly Assembly assembly;
+        private readonly IFileProvider fileProvider;
+        private readonly DateTimeOffset lastModified;
+
+        public EmbeddedEndsWithFileProvider(Assembly assembly)
+        {
+            this.assembly = assembly;
+            this.fileProvider = new EmbeddedFileProvider(assembly);
+            this.lastModified = DateTimeOffset.UtcNow;
+        }
+
+        public EmbeddedEndsWithFileProvider(Assembly assembly, IFileProvider fileProvider)
+        {
+            this.assembly = assembly;
+            this.fileProvider = fileProvider;
+            this.lastModified = DateTimeOffset.UtcNow;
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            IFileInfo fileInfo = fileProvider.GetFileInfo(subpath);
+
+            if (fileInfo is NotFoundFileInfo)
+            {
+                fileInfo = GetFileInfoEndsWith(subpath);
+            }
+
+            return fileInfo;
+        }
+
+        private IFileInfo GetFileInfoEndsWith(string subpath)
+        {
+            if (string.IsNullOrEmpty(subpath))
+            {
+                return new NotFoundFileInfo(subpath);
+            }
+
+            string name = Path.GetFileName(subpath);
+            subpath = subpath.Replace("\\", ".").Replace("/", ".");
+            string resourceNameMatch = assembly.GetManifestResourceNames().LastOrDefault(resourceName => resourceName.EndsWith(subpath));
+
+            if (string.IsNullOrEmpty(resourceNameMatch))
+            {
+                return new NotFoundFileInfo(name);
+            }
+
+            return new EmbeddedResourceFileInfo(this.assembly, resourceNameMatch, name, this.lastModified);
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+            return fileProvider.GetDirectoryContents(subpath);
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            return fileProvider.Watch(filter);
+        }
+    }
+}

--- a/src/ExtCore.Mvc/MvcExtension.cs
+++ b/src/ExtCore.Mvc/MvcExtension.cs
@@ -57,7 +57,7 @@ namespace ExtCore.Mvc
         o =>
         {
           foreach (Assembly assembly in ExtensionManager.Assemblies)
-            o.FileProviders.Add(new EmbeddedFileProvider(assembly, assembly.GetName().Name));
+            o.FileProviders.Add(new EmbeddedEndsWithFileProvider(assembly));
         }
       );
 

--- a/src/ExtCore.Mvc/project.json
+++ b/src/ExtCore.Mvc/project.json
@@ -21,5 +21,5 @@
     "iconUrl": "http://extcore.net/extcore_nuget_icon.png",
     "projectUrl": "http://extcore.net/"
   },
-  "version": "1.0.0-rc1"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Added a new `IFileProvider` that will query an assembly's resources to find a match using `EndsWith()`, but only after the original `EmbeddedFileProvider` fails to find a match. This way, we can still get updates to this provider in the future.

I have recreated the issue as described in Issue #22 and can confirm as working, but there may be instances where `EndsWith()` will match a file that it shouldn't, so I'm open to suggestions.
