### PR TITLE
Fix #89

### DIFF
--- a/src/ExtCore.Data.EntityFramework.MySql/StorageContext.cs
+++ b/src/ExtCore.Data.EntityFramework.MySql/StorageContext.cs
@@ -22,7 +22,7 @@ namespace ExtCore.Data.EntityFramework.MySql
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
       base.OnConfiguring(optionsBuilder);
-      optionsBuilder.UseMySQL(this.ConnectionString);
+      optionsBuilder.UseMySQL(this.ConnectionString, b => b.MigrationsAssembly(this.MigrationsAssembly));
     }
   }
 }

--- a/src/ExtCore.Data.EntityFramework.PostgreSql/StorageContext.cs
+++ b/src/ExtCore.Data.EntityFramework.PostgreSql/StorageContext.cs
@@ -21,7 +21,7 @@ namespace ExtCore.Data.EntityFramework.PostgreSql
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
       base.OnConfiguring(optionsBuilder);
-      optionsBuilder.UseNpgsql(this.ConnectionString);
+      optionsBuilder.UseNpgsql(this.ConnectionString, b => b.MigrationsAssembly(this.MigrationsAssembly));
     }
   }
 }

--- a/src/ExtCore.Data.EntityFramework.SqlServer/StorageContext.cs
+++ b/src/ExtCore.Data.EntityFramework.SqlServer/StorageContext.cs
@@ -21,7 +21,7 @@ namespace ExtCore.Data.EntityFramework.SqlServer
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
       base.OnConfiguring(optionsBuilder);
-      optionsBuilder.UseSqlServer(this.ConnectionString);
+      optionsBuilder.UseSqlServer(this.ConnectionString, b => b.MigrationsAssembly(this.MigrationsAssembly));
     }
   }
 }

--- a/src/ExtCore.Data.EntityFramework.Sqlite/StorageContext.cs
+++ b/src/ExtCore.Data.EntityFramework.Sqlite/StorageContext.cs
@@ -21,7 +21,7 @@ namespace ExtCore.Data.EntityFramework.Sqlite
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
       base.OnConfiguring(optionsBuilder);
-      optionsBuilder.UseSqlite(this.ConnectionString);
+      optionsBuilder.UseSqlite(this.ConnectionString, b => b.MigrationsAssembly(this.MigrationsAssembly));
     }
   }
 }

--- a/src/ExtCore.Data.EntityFramework/StorageContextBase.cs
+++ b/src/ExtCore.Data.EntityFramework/StorageContextBase.cs
@@ -19,12 +19,18 @@ namespace ExtCore.Data.EntityFramework
     public string ConnectionString { get; private set; }
 
     /// <summary>
+    /// The assembly name that is used to design entity framework migrations.
+    /// </summary>
+    public string MigrationsAssembly { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="StorageContext">StorageContext</see> class.
     /// </summary>
     /// <param name="connectionStringProvider">The connection string that is used to connect to the physical storage.</param>
     public StorageContextBase(IOptions<StorageContextOptions> options)
     {
       this.ConnectionString = options.Value.ConnectionString;
+      this.MigrationsAssembly = options.Value.MigrationsAssembly;
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/ExtCore.Data.EntityFramework/StorageContextOptions.cs
+++ b/src/ExtCore.Data.EntityFramework/StorageContextOptions.cs
@@ -12,5 +12,10 @@ namespace ExtCore.Data.EntityFramework
     /// The connection string that is used to connect to the physical storage.
     /// </summary>
     public string ConnectionString { get; set; }
+
+    /// <summary>
+    /// The assembly name that is used to design entity framework migrations.
+    /// </summary>
+    public string MigrationsAssembly { get; set; }
   }
 }

--- a/src/ExtCore.Mvc/Actions/AddStaticFilesAction.cs
+++ b/src/ExtCore.Mvc/Actions/AddStaticFilesAction.cs
@@ -33,7 +33,9 @@ namespace ExtCore.Mvc.Actions
     /// </param>
     public void Execute(IServiceCollection services, IServiceProvider serviceProvider)
     {
-      serviceProvider.GetService<IHostingEnvironment>().WebRootFileProvider = this.CreateCompositeFileProvider(serviceProvider);
+      var env = serviceProvider.GetService<IHostingEnvironment>();
+      if (env != null)
+        env.WebRootFileProvider = this.CreateCompositeFileProvider(serviceProvider);
     }
 
     private IFileProvider CreateCompositeFileProvider(IServiceProvider serviceProvider)

--- a/src/ExtCore.WebApplication/DefaultAssemblyProvider.cs
+++ b/src/ExtCore.WebApplication/DefaultAssemblyProvider.cs
@@ -43,18 +43,19 @@ namespace ExtCore.WebApplication
     {
       this.logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger("ExtCore.WebApplication");
       this.IsCandidateAssembly = assembly =>
-        !assembly.FullName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) &&
-        !assembly.FullName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase);
+        !assembly.FullName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) &&
+        !assembly.FullName.StartsWith("System.", StringComparison.OrdinalIgnoreCase);
 
       this.IsCandidateCompilationLibrary = library =>
-        !library.Name.StartsWith("System.", StringComparison.OrdinalIgnoreCase) &&
-        !library.Name.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) &&
-        !library.Name.StartsWith("Newtonsoft.", StringComparison.OrdinalIgnoreCase) &&
-        !library.Name.StartsWith("runtime.", StringComparison.OrdinalIgnoreCase) &&
-        !library.Name.Equals("NETStandard.Library", StringComparison.OrdinalIgnoreCase) &&
         !library.Name.Equals("Libuv", StringComparison.OrdinalIgnoreCase) &&
+        !library.Name.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) &&
+        !library.Name.Equals("NETStandard.Library", StringComparison.OrdinalIgnoreCase) &&
+        !library.Name.StartsWith("Newtonsoft.", StringComparison.OrdinalIgnoreCase) &&
+        !library.Name.StartsWith("Npgsql", StringComparison.OrdinalIgnoreCase) &&
         !library.Name.Equals("Remotion.Linq", StringComparison.OrdinalIgnoreCase) &&
+        !library.Name.StartsWith("runtime.", StringComparison.OrdinalIgnoreCase) &&
         !library.Name.Equals("StackExchange.Redis.StrongName", StringComparison.OrdinalIgnoreCase) &&
+        !library.Name.StartsWith("System.", StringComparison.OrdinalIgnoreCase) &&
         !library.Name.Equals("WindowsAzure.Storage", StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
This is for enabling ef migrations support #89 (Its working on SqlServer and PostgreSql, need to test the other drivers):

as suggested [here](https://github.com/aspnet/EntityFramework.Docs/blob/master/entity-framework/core/miscellaneous/configuring-dbcontext.md) in your Host project, you just have to create this class **StorageContextDesignTimeDbContextFactory.cs** (change the connectionstring, and the driver you are using, 3rd line)

```
using ExtCore.Data.Abstractions;
using ExtCore.Data.EntityFramework;
using ExtCore.Data.EntityFramework.PostgreSql; // <---- *** Change this for your driver ***
using ExtCore.WebApplication.Extensions;
using Microsoft.EntityFrameworkCore;
using Microsoft.EntityFrameworkCore.Design;
using Microsoft.Extensions.DependencyInjection;
using System.Reflection;

namespace Host
{
    public class StorageContextDesignTimeDbContextFactory : IDesignTimeDbContextFactory<StorageContext>
    {
        public StorageContext CreateDbContext(string[] args)
        {
            var connectionString = "Host=localhost;Port=5432;User ID=extensions;Password=extensions123*;Database=extensions;Pooling=true;";
            var migrationsAssembly = typeof(StorageContextDesignTimeDbContextFactory).GetTypeInfo().Assembly.GetName().Name;

            // create service collection
            var servicesCollection = new ServiceCollection().AddLogging();

            servicesCollection.AddExtCore();
            servicesCollection.Configure<StorageContextOptions>(options =>
            {
                options.ConnectionString = connectionString;
                options.MigrationsAssembly = migrationsAssembly;
            });

            var serviceProvider = servicesCollection.BuildServiceProvider();
            var storage = serviceProvider.GetService<IStorage>();

            return storage.StorageContext as StorageContext;
        }
    }
}
```

![image](https://user-images.githubusercontent.com/26279057/31035632-56950fc0-a52e-11e7-83fc-5cdc24602950.png)
